### PR TITLE
fix(tablero): boat longer than coordinates fixed

### DIFF
--- a/jugador.rb
+++ b/jugador.rb
@@ -14,7 +14,7 @@ class Jugador # rubocop:disable Metrics/ClassLength
     @lado = difs[dif.to_i - 1]
     @tablero = Tablero.new(@lado)
     @tablero_privado = Tablero.new(@lado)
-    @cant_barcos = 1 # 3 * difs[dif.to_i - 1] / 7
+    @cant_barcos = 3 * difs[dif.to_i - 1] / 7
     @largo_barcos = barcs.take(@cant_barcos)
     inicializar_barcos
   end

--- a/tablero.rb
+++ b/tablero.rb
@@ -74,8 +74,11 @@ class Tablero
     end
 
     if col1 == col2
+      return [false, 1] if largo > ((fil2 - fil1).abs + 1)
+
       fils = 0
       cas = []
+
       (0..(largo - 1)).each do |i|
         return [false, 1] unless (@casillas[fil1 + 1 + i][col1 + 1]) == 0 # rubocop:disable Style/NumericPredicate
 


### PR DESCRIPTION
¿Qué se hizo?
Se arregló un bug cuando el largo del barco era mayor que las coordenadas dadas para ubicar el barco. Este error solo ocurria en el caso que las coordenadas estuvieran en la misma columna

¿Qué falta?
-